### PR TITLE
Removed strange bytes to make example cbor diagnostic compliant

### DIFF
--- a/draft-ietf-ace-cwt-proof-of-possession.xml
+++ b/draft-ietf-ace-cwt-proof-of-possession.xml
@@ -304,7 +304,7 @@
    /kty/ 1 : /Symmetric/ 4,
    /alg/ 3 : /HMAC256/ 5,
    /k/ -1 : h'6684523ab17337f173500e5728c628547cb37df
-              e68449c65f885d1b73b49eae1A0B0C0D0E0F10'
+              e68449c65f885d1b73b49eae1'
   }
 ]]></artwork>
 	</figure>


### PR DESCRIPTION
There seem to have been slipping in some extra characters when converting form bas64url to hex encoding. This PR removes them and now the example is accepted by cbor.me

https://github.com/cwt-cnf/i-d/commit/2cb2ca0f09ad44cc9c4022204dd5efb25f5843c2

Fix for comment by Roman from "[Ace] Syntax check of examples in draft-ietf-ace-cwt-proof-of-possession-05"