### PR TITLE
Addressing Ben's final remarks

### DIFF
--- a/draft-ietf-ace-cwt-proof-of-possession.xml
+++ b/draft-ietf-ace-cwt-proof-of-possession.xml
@@ -98,13 +98,13 @@
   <middle>
     <section title="Introduction" anchor="Introduction">
       <t>
-        This specification describes how a CBOR Web Token (CWT) <xref target="RFC8392"/> can declare
+        This specification describes how a CBOR Web Token (CWT) <xref target="CWT"/> can declare
 	that the presenter of the CWT possesses a particular proof-of-possession (PoP) key.
 	Proof of possession of a key is also sometimes described as
 	being the holder-of-key.
 	This specification provides equivalent functionality to
 	"Proof-of-Possession Key Semantics for JSON Web Tokens (JWTs)" <xref target="RFC7800"/>
-	but using CBOR <xref target="RFC7049"/> and CWTs <xref target="RFC8392"/>
+	but using CBOR <xref target="RFC7049"/> and CWTs <xref target="CWT"/>
 	rather than JSON <xref target="RFC8259"/> and JWTs <xref target="JWT"/>.
      </t>
     </section>
@@ -121,7 +121,7 @@
 
       <t>
 	This specification uses terms defined in
-	the CBOR Web Token (CWT) <xref target="RFC8392"/>,
+	the CBOR Web Token (CWT) <xref target="CWT"/>,
 	CBOR Object Signing and Encryption (COSE) <xref target="RFC8152"/>, and
 	Concise Binary Object Representation (CBOR) <xref target="RFC7049"/>
 	specifications.
@@ -177,13 +177,13 @@
 	The presenter can be identified in one of several ways by the CWT,
 	depending upon the application requirements.
 	For instance, some applications may use
-	the CWT <spanx style="verb">sub</spanx> (subject) claim <xref target="RFC8392"/>,
+	the CWT <spanx style="verb">sub</spanx> (subject) claim <xref target="CWT"/>,
 	to identify the presenter.
 	Other applications may use
 	the <spanx style="verb">iss</spanx> claim
 	to identify the presenter.
 	In some applications, the subject identifier might be relative to
-	the issuer identified by the <spanx style="verb">iss</spanx> (issuer) claim <xref target="RFC8392"/>.
+	the issuer identified by the <spanx style="verb">iss</spanx> (issuer) claim <xref target="CWT"/>.
 	The actual mechanism used is dependent upon the application.
 	The case in which the presenter is the subject of the CWT is analogous to
 	Security Assertion Markup Language (SAML) 2.0 <xref target="OASIS.saml-core-2.0-os"/> SubjectConfirmation usage.
@@ -284,8 +284,9 @@
 	  The <spanx style="verb">COSE_Key</spanx> member MAY also be used for a COSE_Key
 	  representing a symmetric key, provided that the CWT is encrypted
 	  so that the key is not revealed to unintended parties.
-	  The means of encrypting a CWT is explained in <xref target="RFC8392"/>.
-	  If the CWT is not encrypted, the symmetric key MUST be encrypted as described in <xref target="SymmetricPoP"/>.
+	  The means of encrypting a CWT is explained in <xref target="CWT"/>.
+	  If the CWT is not encrypted, the symmetric key MUST be encrypted as described in <xref target="SymmetricPoP"/>.  This procedure is equivalent to
+	  the one defined in section 3.3 of <xref target="RFC7800"/>.
 	</t>
       </section>
 
@@ -347,9 +348,9 @@
 	<t>
 	The example above was generated with the key:
 	</t>
-	<figure>
+        <figure>
 	  <artwork><![CDATA[
-	  h'6162630405060708090a0b0c0d0e0f10'
+          h'6162630405060708090a0b0c0d0e0f10'
 ]]></artwork>
 	</figure>
       </section>
@@ -480,7 +481,7 @@
     <section anchor="Security" title="Security Considerations">
       <t>
         All the security considerations that
-        are discussed in <xref target="RFC8392"/> also apply here.
+        are discussed in <xref target="CWT"/> also apply here.
         In addition, proof of possession introduces its own unique security issues.
 	Possessing a key is only valuable if it is kept secret.
 	Appropriate means must be used to ensure that unintended parties
@@ -488,7 +489,7 @@
       </t>
       <t>
 	Applications utilizing proof of possession SHOULD also utilize audience restriction,
-	as described in Section 4.1.3 of <xref target="JWT"/>,
+	as described in Section 4.1.3 of <xref target="CWT"/>,
 	as it provides additional protections.
 	Audience restriction can be used by recipients to reject messages intended for different recipients.
       </t>
@@ -524,7 +525,7 @@
 	but also confidentiality protection
 	(e.g., either by encrypting the <spanx style="verb">cnf</spanx> element,
 	as specified in <xref target="SymmetricPoP"/>,
-	or by encrypting the whole CWT, as specified in <xref target="RFC8392"/>).
+	or by encrypting the whole CWT, as specified in <xref target="CWT"/>).
       </t>
       <t>
 	As described in Section 6 (Key Identification) and Appendix D (Notes on Key Selection)
@@ -618,7 +619,7 @@
 	<t>
 	  This specification registers the <spanx style="verb">cnf</spanx> claim in the IANA
 	  "CBOR Web Token Claims" registry <xref target="IANA.CWT.Claims"/>
-	  established by <xref target="RFC8392"/>.
+	  established by <xref target="CWT"/>.
 	</t>
 
 	<section anchor='ClaimsContents' title='Registry Contents'>
@@ -826,8 +827,6 @@
       <?rfc include='http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8126.xml' ?>
       <?rfc include='http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8152.xml' ?>
       <?rfc include='http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml' ?>
-      <?rfc include='http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8392.xml' ?>
-
       <reference anchor="IANA.CWT.Claims" target="http://www.iana.org/assignments/cwt">
         <front>
           <title>CBOR Web Token Claims</title>
@@ -836,6 +835,38 @@
           </author>
 	  <date/>
         </front>
+      </reference>
+
+      <reference anchor="CWT" target="http://www.rfc-editor.org/info/rfc8392">
+        <front>
+          <title>CBOR Web Token (CWT)</title>
+	  <author fullname="Michael B. Jones" initials="M.B." surname="Jones">
+	    <organization>Microsoft</organization>
+	    <address>
+	      <email>mbj@microsoft.com</email>
+	      <uri>http://self-issued.info/</uri>
+	    </address>
+	  </author>
+	  <author fullname="Erik Wahlström" initials="E." surname="Wahlström">
+	    <address>
+	      <email>erik@wahlstromstekniska.se</email>
+	    </address>
+	  </author>
+	  <author fullname="Samuel Erdtman" initials="S." surname="Erdtman">
+	    <organization>Spotify AB</organization>
+	    <address>
+	      <email>erdtman@spotify.com</email>
+	    </address>
+	  </author>
+	  <author fullname="Hannes Tschofenig" initials="H." surname="Tschofenig">
+	    <organization>ARM Ltd.</organization>
+	    <address>
+	      <email>Hannes.Tschofenig@arm.com</email>
+	    </address>
+	  </author>
+	  <date month="May" year="2018"/>
+        </front>
+        <seriesInfo name="RFC" value="8392" />
       </reference>
 
     </references>
@@ -870,7 +901,7 @@
         </front>
         <seriesInfo name="RFC" value="7515" />
       </reference>
-
+      
       <reference anchor="JWT" target='http://www.rfc-editor.org/info/rfc7519'>
         <front>
           <title>JSON Web Token (JWT)</title>

--- a/draft-ietf-ace-cwt-proof-of-possession.xml
+++ b/draft-ietf-ace-cwt-proof-of-possession.xml
@@ -996,7 +996,7 @@
 	Jim Schaad.
       </t>
       <t>Ludwig Seitz and Göran Selander worked on this document as part of
-    the CelticPlus project CyberWI, with funding from Vinnova.</t>
+    the CelticPlus projects CyberWI and CRITISEC, with funding from Vinnova.</t>
     </section>
 
     <section title="Document History" anchor="History">

--- a/draft-ietf-ace-cwt-proof-of-possession.xml
+++ b/draft-ietf-ace-cwt-proof-of-possession.xml
@@ -406,6 +406,12 @@
 	  there is frequently a restriction on the size of Key IDs,
 	  either because of table constraints or a desire to keep message sizes small.
 	</t>
+	<t>Note that the value of a Key ID for a specific key is not
+	necessarily the same for different parties. When sending a COSE
+	encrypted message with a shared key, the Key ID may be different on
+	both sides of the conversation,	with the appropriate one being included
+	in the message based on the recipient of the message.
+	</t>
       </section>
 
 <!--


### PR DESCRIPTION
This PR addresses the following remarks from Ben:

> (1) In Section 3.2 (Representation of an Asymmetric Proof-of-Possession
> Key), the last paragraph is a somewhat different from the main content, in
> that it mentions using "COSE_Key" for an encrypted symmetric key, analogous
> to the last paragraph of Section 3.2 of RFC 7800.  I had wanted to see some
> additional discussion, but we agreed that this was analogous to RFC 7800
> and we did not need to go "out of parity" with it on this point.  So we
> should be able to go ahead without new text here, but did we want to
> explicitly refer back to that portion of RFC 7800 to make the connection
> clear?
>
> (2) In https://github.com/cwt-cnf/i-d/pull/27/files we removed a large
> chunk of text since it contained several things that are inaccurate.  The
> only things that were removed that I wanted to check if we should think
> about keeping was the note that the same key might be referred to by
> different key IDs in messages directed to different recipients.  What do
> people think about that?
>
> (3) I think we were going to change the [JWT] reference to [CWT], in
> Section 4:
>>   Applications utilizing proof of possession SHOULD also utilize
>>  audience restriction, as described in Section 4.1.3 of [JWT], as it
>>   provides additional protections.  Audience restriction can be used by
>>   recipients to reject messages intended for different recipients.
>
> That way we won't get asked to make [JWT] a normative reference.
